### PR TITLE
deterministic random for SSR

### DIFF
--- a/src/lib/random.ts
+++ b/src/lib/random.ts
@@ -1,0 +1,16 @@
+import {browser} from '$app/env';
+
+export const VARY_RANDOM = 0.2;
+
+// TODO copypasta from `corpus-activity-streams` then refactored
+// TODO import random utils from `felt` using `uid` probably
+export const toRandom: ToRandom = () => Math.random();
+export interface ToRandom {
+	(): number;
+}
+export interface ToToRandom {
+	(i?: number): ToRandom;
+}
+export const toToDeterministicRandom: ToToRandom = (i = 0) => () => VARY_RANDOM + i++ / 10000000000;
+
+export const random: ToRandom = browser ? toRandom : toToDeterministicRandom();

--- a/src/lib/shadow.ts
+++ b/src/lib/shadow.ts
@@ -1,9 +1,10 @@
 import {getContext, setContext} from 'svelte';
-import {browser} from '$app/env';
+
+import {random} from '$lib/random';
 
 const shadowKey = {};
 
-export const provideShadow = (initial = randomShadow()) => {
+export const provideShadow = (initial = toRandomShadow()): void => {
 	setContext(shadowKey, initial);
 };
 
@@ -11,4 +12,4 @@ export const useShadow = (): boolean => {
 	return getContext(shadowKey);
 };
 
-export const randomShadow = (): boolean => (browser ? Math.random() > 0.5 : false);
+export const toRandomShadow = (): boolean => random() > 0.5;

--- a/src/routes/tarot/index.svelte
+++ b/src/routes/tarot/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Overlay from '$lib/Overlay.svelte';
-	import {randomShadow} from '$lib/shadow';
+	import {toRandomShadow} from '$lib/shadow';
 	import TarotCardThumbnail from '../../tarot/TarotCardThumbnail.svelte';
 	import TarotCardDetail from '../../tarot/TarotCardDetail.svelte';
 	import DrawnTarotCard from '../../tarot/DrawnTarotCard.svelte';
@@ -38,7 +38,7 @@
 {#if drawnCards.length}
 	<Overlay close={() => (drawnCards = [])}>
 		{#each drawnCards as card (card.id)}
-			<DrawnTarotCard {card} shadow={randomShadow()} />
+			<DrawnTarotCard {card} shadow={toRandomShadow()} />
 			{#if card !== last(drawnCards)}
 				<hr />
 			{/if}

--- a/src/tarot/tarot.ts
+++ b/src/tarot/tarot.ts
@@ -1,3 +1,5 @@
+import {random} from '$lib/random';
+
 export type TarotSuit = 'major' | 'wands' | 'cups' | 'swords' | 'coins';
 
 export interface TarotCard {
@@ -26,6 +28,6 @@ const TAROT_COUNT = 78;
 export const randomCardIndex = () => randomInt(0, TAROT_COUNT - 1);
 // TODO import these from Gro - problem with Vite importing the undeclared exports
 export const randomInt = (min: number, max: number): number =>
-	Math.floor(Math.random() * (max - min + 1)) + min;
+	Math.floor(random() * (max - min + 1)) + min;
 export const randomItem = <T>(arr: T[]): T | undefined => arr[randomInt(0, arr.length - 1)];
 export const last = <T>(array: T[]): T | undefined => array[array.length - 1];


### PR DESCRIPTION
Rendering random values on the server is bad because it makes the build nondeterministic. But dealt is so very random, I mean that's it's thing, so how do we solve it? Deterministic random number generators for SSR ought to do it.

The primary concrete problem this solves is maintaining idempotent `gro deploy`.